### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,8 @@ texworks-manual (20150506-5) UNRELEASED; urgency=medium
   * Use secure URI in Homepage field.
   * Bump debhelper from deprecated 9 to 12.
   * Set debhelper-compat version in Build-Depends.
+  * Apply multi-arch hints.
+    + texworks-help-en, texworks-help-fr: Add Multi-Arch: foreign.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 11:09:31 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Package: texworks-help-en
 Architecture: all
 Depends: ${misc:Depends}
 Recommends: texworks
+Multi-Arch: foreign
 Description: English help files for TeXworks
  For furter information, see http://tug.org/texworks/
 
@@ -30,5 +31,6 @@ Package: texworks-help-fr
 Architecture: all
 Depends: ${misc:Depends}
 Recommends: texworks
+Multi-Arch: foreign
 Description: French help files for TeXworks
  For furter information, see http://tug.org/texworks/


### PR DESCRIPTION
Apply hints suggested by the multi-arch hinter.

* texworks-help-en: Add Multi-Arch: foreign. This fixes: texworks-help-en could be marked Multi-Arch: foreign. ([ma-foreign](https://wiki.debian.org/MultiArch/Hints#ma-foreign))
* texworks-help-fr: Add Multi-Arch: foreign. This fixes: texworks-help-fr could be marked Multi-Arch: foreign. ([ma-foreign](https://wiki.debian.org/MultiArch/Hints#ma-foreign))

These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/texworks-manual/70064f77-f31b-45d7-8f26-a326c03a0c50.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package texworks-help-en: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}
### Control files of package texworks-help-fr: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/70064f77-f31b-45d7-8f26-a326c03a0c50/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/70064f77-f31b-45d7-8f26-a326c03a0c50/diffoscope)).
